### PR TITLE
UNPACK fields of Tree

### DIFF
--- a/src/Data/RRBVector/Internal.hs
+++ b/src/Data/RRBVector/Internal.hs
@@ -68,7 +68,7 @@ infixl 5 |>
 -- Nodes are always non-empty.
 data Tree a
     = Balanced {-# UNPACK #-} !(A.Array (Tree a))
-    | Unbalanced {-# UNPACK #-} !(A.Array (Tree a)) {-# UNPACK #-} !(PrimArray Int)
+    | Unbalanced {-# UNPACK #-} !(A.Array (Tree a)) !(PrimArray Int)
     | Leaf {-# UNPACK #-} !(A.Array a)
 
 -- | A vector.

--- a/src/Data/RRBVector/Internal.hs
+++ b/src/Data/RRBVector/Internal.hs
@@ -67,9 +67,9 @@ infixl 5 |>
 -- A Leaf node is considered balanced.
 -- Nodes are always non-empty.
 data Tree a
-    = Balanced !(A.Array (Tree a))
-    | Unbalanced !(A.Array (Tree a)) !(PrimArray Int)
-    | Leaf !(A.Array a)
+    = Balanced {-# UNPACK #-} !(A.Array (Tree a))
+    | Unbalanced {-# UNPACK #-} !(A.Array (Tree a)) {-# UNPACK #-} !(PrimArray Int)
+    | Leaf {-# UNPACK #-} !(A.Array a)
 
 -- | A vector.
 --


### PR DESCRIPTION
For better perf. Result diffs generated with criterion-compare:
```
10/<|                4.7%   4.12e-8
10/><                -7.9%  3.26e-8
10/adjust            -4.7%  3.81e-8
10/drop              -4.8%  1.98e-8
10/foldl             -4.8%  4.14e-8
10/foldr             2.1%   4.69e-8
10/fromList          -1.8%  8.85e-8
10/index             -8.3%  2.06e-8
10/take              -5.6%  1.89e-8
10/|>                3.8%   4.14e-8
100/<|               -1.2%  1.22e-7
100/><               -2.0%  1.17e-6
100/adjust           -7.2%  6.01e-8
100/drop             -0.1%  8.59e-8
100/foldl            -4.3%  4.36e-7
100/foldr            -2.8%  4.49e-7
100/fromList         -5.3%  6.87e-7
100/index            -5.6%  2.35e-8
100/take             -6.5%  4.01e-8
100/|>               -5.6%  5.98e-8
1000/<|              -2.3%  1.44e-7
1000/><              2.5%   4.58e-6
1000/adjust          -5.9%  8.79e-8
1000/drop            -2.7%  1.43e-7
1000/foldl           -3.3%  4.20e-6
1000/foldr           -1.5%  4.28e-6
1000/fromList        -1.4%  6.12e-6
1000/index           5.3%   2.55e-8
1000/take            -5.1%  6.34e-8
1000/|>              -8.6%  9.08e-8
10000/<|             -0.4%  1.52e-7
10000/><             -0.9%  9.21e-6
10000/adjust         -7.4%  1.16e-7
10000/drop           -1.5%  4.04e-7
10000/foldl          -1.6%  4.13e-5
10000/foldr          -1.3%  4.40e-5
10000/fromList       -0.8%  7.01e-5
10000/index          -0.8%  3.04e-8
10000/take           -7.7%  8.58e-8
10000/|>             -7.1%  8.13e-8
100000/<|            -3.0%  1.58e-7
100000/><            -8.5%  2.02e-5
100000/adjust        -8.0%  1.43e-7
100000/drop          2.1%   5.30e-7
100000/foldl         -4.2%  4.34e-4
100000/foldr         -4.0%  4.79e-4
100000/fromList      -15.4% 2.39e-3
100000/index         1.5%   3.27e-8
100000/take          -8.3%  1.13e-7
100000/|>            -5.2%  1.13e-7
```

FTR, I ran the benchmarks with `-O2 -fproc-alignment=64` and deactivated Turbo Boost.