### PR TITLE
Use SmallMutableArray in Internal.Buffer

### DIFF
--- a/src/Data/RRBVector/Internal/Array.hs
+++ b/src/Data/RRBVector/Internal/Array.hs
@@ -14,7 +14,7 @@
 module Data.RRBVector.Internal.Array
     ( Array, MutableArray
     , ifoldrStep, ifoldlStep, ifoldrStep', ifoldlStep'
-    , empty, singleton, from2
+    , empty, singleton, from2, wrap
     , replicate, replicateSnoc
     , index, head, last
     , update, adjust, adjust'
@@ -121,6 +121,9 @@ from2 x y = Array 0 2 $ runSmallArray $ do
     sma <- newSmallArray 2 x
     writeSmallArray sma 1 y
     pure sma
+
+wrap :: SmallArray a -> Array a
+wrap arr = Array 0 (sizeofSmallArray arr) arr
 
 replicate :: Int -> a -> Array a
 replicate n x = Array 0 n $ runSmallArray (newSmallArray n x)

--- a/src/Data/RRBVector/Internal/Buffer.hs
+++ b/src/Data/RRBVector/Internal/Buffer.hs
@@ -13,25 +13,29 @@ module Data.RRBVector.Internal.Buffer
 
 import Control.Monad.ST
 
+import Data.Primitive.SmallArray
 import Data.RRBVector.Internal.IntRef
 import qualified Data.RRBVector.Internal.Array as A
 
 -- | A mutable array buffer with a fixed capacity.
-data Buffer s a = Buffer !(A.MutableArray s a) !(IntRef s)
+data Buffer s a = Buffer !(SmallMutableArray s a) !(IntRef s)
 
 -- | \(O(n)\). Create a new empty buffer with the given capacity.
 new :: Int -> ST s (Buffer s a)
 new capacity = do
-    buffer <- A.new capacity
+    buffer <- newSmallArray capacity uninitialized
     offset <- newIntRef 0
     pure (Buffer buffer offset)
+
+uninitialized :: a
+uninitialized = errorWithoutStackTrace "uninitialized"
 
 -- | \(O(1)\). Push a new element onto the buffer.
 -- The size of the buffer must not exceed the capacity, but this is not checked.
 push :: Buffer s a -> a -> ST s ()
 push (Buffer buffer offset) x = do
     idx <- readIntRef offset
-    A.write buffer idx x
+    writeSmallArray buffer idx x
     writeIntRef offset (idx + 1)
 
 -- | \(O(n)\). Freeze the content of the buffer and return it.
@@ -39,9 +43,9 @@ push (Buffer buffer offset) x = do
 get :: Buffer s a -> ST s (A.Array a)
 get (Buffer buffer offset) = do
     len <- readIntRef offset
-    result <- A.freeze buffer 0 len
+    result <- freezeSmallArray buffer 0 len
     writeIntRef offset 0
-    pure result
+    pure (A.wrap result)
 
 -- | \(O(1)\). Return the current size of the buffer.
 size :: Buffer s a -> ST s Int


### PR DESCRIPTION
...instead of Internal.Array.
Since a Buffer doesn't need to support slicing, this will reduce the memory footprint of a Buffer (in case GHC can't optimize the indirection and offset and length away).

Fixes #13